### PR TITLE
Fixed creation of not instantiated Prototype beans while tearing them down

### DIFF
--- a/src/org/swizframework/core/BeanFactory.as
+++ b/src/org/swizframework/core/BeanFactory.as
@@ -381,6 +381,12 @@ package org.swizframework.core
 		 */
 		public function tearDownBean( bean:Bean ):void
 		{
+			if( bean is Prototype && ( Prototype( bean ).singleton == false || Prototype( bean ).initialized == false ) )
+			{
+				logger.debug( 'BeanFactory skipped uninitialized singleton prototype bean {0}', bean.toString() );
+				return;
+			}
+
 			for each( var processor:IProcessor in swiz.processors )
 			{
 				// skip factory processors


### PR DESCRIPTION
Fixed creation of not instantiated Prototype beans while tearing them down. The isue described here: http://groups.google.com/group/swiz-framework/browse_thread/thread/c7c87964ab59008e
