### PR TITLE
Introduction of 'design.xml' for Swiz Code Designer integration

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -2,10 +2,12 @@
 swiz.version = v1.2.0
 swiz.name = swiz-framework-${swiz.version}
 swiz.name.flex3 = ${swiz.name}-flex3
-swiz.namespace = http://swiz.swizframework.org
+#swiz.namespace = http://swiz.swizframework.org
+swiz.namespace = library://ns.swizframework.org/swiz
 
 # flex sdk
-flex.sdk = /Applications/Adobe\ Flash\ Builder\ 4\ Plug-in/sdks/4.0.0
+#flex.sdk = /Applications/Adobe\ Flash\ Builder\ 4\ Plug-in/sdks/4.0.0
+flex.sdk = /Users/pepebarragan/Library/Frameworks/Flex/4.5.1
 
 # Unit tests
 test.application.name = SwizTestRunner.mxml

--- a/build/build.xml
+++ b/build/build.xml
@@ -82,6 +82,7 @@
 			<include-namespaces uri="${swiz.namespace}" />
 			
 			<include-file name="metadata.xml" path="${src.loc}/metadata.xml" />
+            <include-file name="design.xml" path="${src.loc}/design.xml" />
 			
 			<!-- add flex3/flex4 compiler arg -->
 			<compiler.define name="CONFIG::flex3" value="false" />

--- a/src/design.xml
+++ b/src/design.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<design>
+    <!--- Only the classes that can be declared in mxml -->
+    <namespaces>
+        <namespace prefix="sf" uri="library://ns.swizframework.org/swiz" />
+    </namespaces>
+ 
+    <categories>
+        <category id="swiz" label="Swiz" defaultExpand="true" />
+    </categories>
+    
+    <components>
+        <component name="Swiz" namespace="sf" category="swiz" insertStyle="control" displayName="Swiz">
+            <mxmlProperties use="sf:Swiz" />
+        </component>
+        
+        <!-- core package -->
+        <component name="SwizConfig" namespace="sf" category="swiz" insertStyle="control" displayName="Swiz Config">
+            <mxmlProperties use="sf:SwizConfig" />
+        </component>
+        <component name="Bean" namespace="sf" category="swiz" insertStyle="control" displayName="Bean">
+            <mxmlProperties use="sf:Bean" />
+        </component>
+        <component name="BeanFactory" namespace="sf" category="swiz" insertStyle="control" displayName="Bean Factory">
+            <mxmlProperties use="sf:BeanFactory" />
+        </component>
+        <component name="BeanProvider" namespace="sf" category="swiz" insertStyle="control" displayName="Bean Provider">
+            <mxmlProperties use="sf:BeanProvider" />
+        </component>
+        <component name="BeanLoader" namespace="sf" category="swiz" insertStyle="control" displayName="Bean Loader">
+            <mxmlProperties use="sf:BeanLoader" />
+        </component>
+        
+        <!-- utils package -->
+        <component name="ServiceHelper" namespace="sf" category="swiz" insertStyle="control" displayName="Service Helper">
+            <mxmlProperties use="sf:ServiceHelper" />
+        </component>
+        <component name="ChannelSetHelper" namespace="sf" category="swiz" insertStyle="control" displayName="ChannelSet Helper">
+            <mxmlProperties use="sf:ChannelSetHelper" />
+        </component>
+        <component name="URLRequestHelper" namespace="sf" category="swiz" insertStyle="control" displayName="URL Request Helper">
+            <mxmlProperties use="sf:URLRequestHelper" />
+        </component>
+        
+    </components>
+</design>

--- a/src/org/swizframework/events/SwizEvent.as
+++ b/src/org/swizframework/events/SwizEvent.as
@@ -30,20 +30,20 @@ package org.swizframework.events
 		// ========================================
 		
 		/**
-		 * The BeanEvent.ADDED constant defines the value of the type property
-		 * of a beanAdded event object.
+		 * The SwizEvent.CREATED constant defines the value of the type property
+		 * of a swizCreated event object.
 		 */
 		public static const CREATED:String = "swizCreated";
 		
 		/**
-		 * The BeanEvent.LOAD_COMPLETE constant defines the value of the type property
+		 * The SwizEvent.LOAD_COMPLETE constant defines the value of the type property
 		 * of an initial load complete event object.
 		 */
 		public static const LOAD_COMPLETE:String = "loadComplete";
 		
 		/**
-		 * The BeanEvent.REMOVED constant defines the value of the type property
-		 * of a beanRemoved event object.
+		 * The SwizEvent.DESTROYED constant defines the value of the type property
+		 * of a swizDestroyed event object.
 		 */
 		public static const DESTROYED:String = "swizDestroyed";
 		


### PR DESCRIPTION
It works fine with FlashBuilder' MXML code designer, that's the point :) 
But I'm not sure about if the 'design.xml' it's fully complete, it will be necessary to review if lack to complete the document, with more components or less.

I'm introduce a new swiz namespace too with the new format style: 'library://ns.swizframework.org/swiz'

Regards
