### PR TITLE
SharedObjectBean patch

### DIFF
--- a/src/org/swizframework/storage/SharedObjectBean.as
+++ b/src/org/swizframework/storage/SharedObjectBean.as
@@ -63,6 +63,8 @@ package org.swizframework.storage
 		
 		public function SharedObjectBean()
 		{
+			super();
+			invalidate();
 		}
 		
 		protected function invalidate():void


### PR DESCRIPTION
Fixes SWIZ-40 by adding invalidate() call to SharedObjectBean constructor.

Spoke with Sonke and he agreed this should be added.
