### PR TITLE
CommandMap eventType collisions fix

### DIFF
--- a/src/org/swizframework/utils/commands/CommandMap.as
+++ b/src/org/swizframework/utils/commands/CommandMap.as
@@ -66,7 +66,7 @@ package org.swizframework.utils.commands
 					
 					// validate event class
 					if( !( event is commandMapping.eventClass ) )
-						return;
+						continue;
 					
 					// get our command bean
 					var commandPrototype:Bean = _swiz.beanFactory.getBeanByType( commandMapping.commandClass );


### PR DESCRIPTION
Previous 'return' returned you out of the function all together, this allows you to continue searching for a possible eventClass match in other commandMappings
