### PR TITLE
Fixed issue with erroneous "invalid tag" error message

### DIFF
--- a/src/org/swizframework/processors/EventHandlerProcessor.as
+++ b/src/org/swizframework/processors/EventHandlerProcessor.as
@@ -126,7 +126,7 @@ package org.swizframework.processors
 		 */
 		protected function addEventHandlerByEventType( eventHandlerTag:EventHandlerMetadataTag, method:Function, eventClass:Class, eventType:String ):void
 		{
-			var eventHandler:EventHandler = new eventHandlerClass( eventHandlerTag, method, eventClass );
+			var eventHandler:EventHandler = new eventHandlerClass( eventHandlerTag, method, eventClass, swiz.domain );
 			
 			eventHandlersByEventType[ eventType ] ||= [];
 			eventHandlersByEventType[ eventType ].push( eventHandler );


### PR DESCRIPTION
Modified EventHandler to allow for methods that accept a type compatible with, but not necessarily matching, the type specified in [EventHandler] tag.
