### PR TITLE
Fix SWIZ-62 by ensuring bean source is not null before attempting tear down

### DIFF
--- a/src/org/swizframework/core/BeanFactory.as
+++ b/src/org/swizframework/core/BeanFactory.as
@@ -380,6 +380,9 @@ package org.swizframework.core
 		 */
 		public function tearDownBean( bean:Bean ):void
 		{
+			if( bean.source == null )
+				return;
+				
 			for each( var processor:IProcessor in swiz.processors )
 			{
 				// skip factory processors


### PR DESCRIPTION
Fix SWIZ-62 by ensuring bean source is not null before attempting tear down.

Basically a simple fix for http://swizframework.jira.com/browse/SWIZ-62, where removing a bean will later cause an error when the Swiz instance is torn down (because the removed bean in the BeanProvider now has no source).
