### PR TITLE
fix for bugs 66, 67 related to teardown problems

### DIFF
--- a/src/org/swizframework/core/BeanFactory.as
+++ b/src/org/swizframework/core/BeanFactory.as
@@ -256,7 +256,6 @@ package org.swizframework.core
 			if( !( bean is Prototype ) || Prototype( bean ).initialized )
 				tearDownBean( bean );
 			
-			tearDownBean( bean );
 			bean.beanFactory = null;
 			bean.typeDescriptor = null;
 			bean.source = null;

--- a/src/org/swizframework/core/BeanFactory.as
+++ b/src/org/swizframework/core/BeanFactory.as
@@ -253,6 +253,9 @@ package org.swizframework.core
 			if( beans.indexOf( bean ) > -1 )
 				beans.splice( beans.indexOf( bean ), 1 );
 			
+			if( !( bean is Prototype ) || Prototype( bean ).initialized )
+				tearDownBean( bean );
+			
 			tearDownBean( bean );
 			bean.beanFactory = null;
 			bean.typeDescriptor = null;

--- a/src/org/swizframework/core/Swiz.as
+++ b/src/org/swizframework/core/Swiz.as
@@ -349,6 +349,8 @@ package org.swizframework.core
 			// tear down beans defined in bean providers or added with BeanEvents
 			beanFactory.tearDown();
 			
+			dispatcher.removeEventListener( SwizEvent.CREATED, handleSwizCreatedEvent );
+			
 			// clear out refs
 			parentSwiz = null;
 			SwizManager.removeSwiz( this );


### PR DESCRIPTION
-tear down not removing swiz creation event listener
http://swizframework.jira.com/browse/SWIZ-67

-tear down setting up prototype beans
http://swizframework.jira.com/browse/SWIZ-66
