### PR TITLE
Conditional discovery of inherited beans on BeanFactory.

### DIFF
--- a/src/org/swizframework/core/BeanFactory.as
+++ b/src/org/swizframework/core/BeanFactory.as
@@ -260,7 +260,7 @@ package org.swizframework.core
 			bean = null;
 		}
 		
-		public function getBeanByName( name:String ):Bean
+		public function getBeanByName( name:String, discovery:Boolean = true ):Bean
 		{
 			var foundBean:Bean = null;
 			
@@ -275,13 +275,13 @@ package org.swizframework.core
 			
 			if( foundBean != null && !( foundBean is Prototype ) && !foundBean.initialized )
 				setUpBean( foundBean );
-			else if( foundBean == null && parentBeanFactory != null )
+			else if( foundBean == null && parentBeanFactory != null && discovery )
 				foundBean = parentBeanFactory.getBeanByName( name );
 			
 			return foundBean;
 		}
 		
-		public function getBeanByType( beanType:Class ):Bean
+		public function getBeanByType( beanType:Class, discovery:Boolean = true ):Bean
 		{
 			var foundBean:Bean;
 			
@@ -302,7 +302,7 @@ package org.swizframework.core
 			
 			if( foundBean != null && !( foundBean is Prototype ) && !foundBean.initialized )
 				setUpBean( foundBean );
-			else if( foundBean == null && parentBeanFactory != null )
+			else if( foundBean == null && parentBeanFactory != null && discovery )
 				foundBean = parentBeanFactory.getBeanByType( beanType );
 			
 			return foundBean;

--- a/src/org/swizframework/core/IBeanFactory.as
+++ b/src/org/swizframework/core/IBeanFactory.as
@@ -35,8 +35,8 @@ package org.swizframework.core
 		function removeBeanProvider( beanProvider:IBeanProvider ):void;
 		
 		function get beans():Array;
-		function getBeanByName( name:String ):Bean;
-		function getBeanByType( type:Class ):Bean;
+		function getBeanByName( name:String, discovery:Boolean = true ):Bean;
+		function getBeanByType( type:Class, discovery:Boolean = true ):Bean;
 		
 		/**
 		 * Parent Swiz instance, for nesting and modules


### PR DESCRIPTION
Optional parameter "discovery" on getBeanByName and getBeanByType methods, default value "true".

This feature, provides control to limit the bean discovery process to local swiz or nesting swiz structure (parent / child).
