### PR TITLE
Introduces the new local attribute on Inject metadata tag.

### DIFF
--- a/src/metadata.xml
+++ b/src/metadata.xml
@@ -28,6 +28,13 @@
 				   type="String" 
 				   required="false"
 				   description="Id of the named bean to inject" />
+
+        <attribute name="local"
+                   type="Boolean"
+                   hint="boolean"
+                   defaultValue="false"
+                   required="false"
+                   description="Denotes whether or not Swiz should use the ( parent / child ) relation, to find the bean that will be injected." />
 				   
 		<attribute name="required" 
 				   type="Boolean" 

--- a/src/org/swizframework/metadata/InjectMetadataTag.as
+++ b/src/org/swizframework/metadata/InjectMetadataTag.as
@@ -55,6 +55,11 @@ package org.swizframework.metadata
 		 * Backing variable for read-only <code>required</code> property.
 		 */
 		protected var _required:Boolean = true;
+
+		/**
+		 * Backing variable for read-only <code>local</code> property.
+		 */
+		protected var _local:Boolean = false;
 		
 		// ========================================
 		// public properties
@@ -117,6 +122,17 @@ package org.swizframework.metadata
 		{
 			return _required;
 		}
+
+		/**
+		 * Returns local attribute of [Inject] tag as a <code>Boolean</code> value.
+		 * If true Swiz will discovery beans only in own instance avoiding parent child structure.
+		 *
+		 * @default false
+		 */
+		public function get local():Boolean
+		{
+			return _local;
+		}
 		
 		// ========================================
 		// constructor
@@ -169,6 +185,9 @@ package org.swizframework.metadata
 			
 			if( hasArg( "required" ) )
 				_required = getArg( "required" ).value == "true";
+
+			if( hasArg( "local" ) )
+				_local = getArg( "local" ).value == "true";
 		}
 	}
 }

--- a/src/org/swizframework/processors/InjectProcessor.as
+++ b/src/org/swizframework/processors/InjectProcessor.as
@@ -106,7 +106,7 @@ package org.swizframework.processors
 				// source attribute found - means we're injecting by name and potentially by property
 				
 				// try to obtain the bean by using the first part of the source attribute
-				var namedBean:Bean = getBeanByName( injectTag.source.split( "." )[ 0 ] );
+				var namedBean:Bean = getBeanByName( injectTag.source.split( "." )[ 0 ], !injectTag.local );
 				
 				if( namedBean == null )
 				{
@@ -216,7 +216,7 @@ package org.swizframework.processors
 		 */
 		protected function removeInjectByProperty( injectTag:InjectMetadataTag, bean:Bean ):void
 		{
-			var namedBean:Bean = getBeanByName( injectTag.source.split( "." )[ 0 ] );
+			var namedBean:Bean = getBeanByName( injectTag.source.split( "." )[ 0 ], !injectTag.local );
 			
 			removePropertyBinding( bean, namedBean, injectTag );
 			
@@ -242,7 +242,7 @@ package org.swizframework.processors
 			{
 				targetType = swiz.domain.getDefinition( injectTag.host.name ) as Class;
 			}
-			var typedBean:Bean = getBeanByType( targetType );
+			var typedBean:Bean = getBeanByType( targetType, !injectTag.local );
 			
 			if( typedBean )
 			{
@@ -322,17 +322,17 @@ package org.swizframework.processors
 		/**
 		 * Get Bean By Name
 		 */
-		protected function getBeanByName( name:String ):Bean
+		protected function getBeanByName( name:String, discovery:Boolean = true ):Bean
 		{
-			return beanFactory.getBeanByName( name );
+			return beanFactory.getBeanByName( name, discovery );
 		}
 		
 		/**
 		 * Get Bean By Type
 		 */
-		protected function getBeanByType( type:Class ):Bean
+		protected function getBeanByType( type:Class, discovery:Boolean = true ):Bean
 		{
-			return beanFactory.getBeanByType( type );
+			return beanFactory.getBeanByType( type, discovery );
 		}
 		
 		/**


### PR DESCRIPTION
Denotes whether or not Swiz should use the parent / child relation, to find the bean that will be injected.
